### PR TITLE
fix a very minor typo

### DIFF
--- a/lib/puppet/provider/transition/ruby.rb
+++ b/lib/puppet/provider/transition/ruby.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:transition).provide(:ruby) do
       end
     end
 
-    # If changes are pending, transtion?() will return true.
+    # If changes are pending, transition?() will return true.
     pending_change
   end
 


### PR DESCRIPTION
This fixes the most inconsequential typo in a comment in the provider for this resource.