### PR TITLE
Correct an error with #10

### DIFF
--- a/examples/notify.pp
+++ b/examples/notify.pp
@@ -1,0 +1,13 @@
+transition { 'run twice':
+  resource   => Notify['message'],
+  attributes => { message => 'This content should display before' },
+  prior_to   => Notify['ending'],
+}
+
+notify { 'message':
+  message => 'This content should display after'
+}
+
+notify { 'ending':
+  message => 'The end'
+}

--- a/lib/puppet/provider/transition/ruby.rb
+++ b/lib/puppet/provider/transition/ruby.rb
@@ -68,10 +68,10 @@ Puppet::Type.type(:transition).provide(:ruby) do
       # (and may trigger false positives).
       current_ensure = current_values[:ensure]
       prop_ensure = resource.property(:ensure)
-      if prop_ensure.should == :absent && prop_ensure.safe_insync?(current_ensure)
+      if prop_ensure && prop_ensure.should == :absent && prop_ensure.safe_insync?(current_ensure)
         next false
       end
-      
+
       resource.properties.any? do |property|
         current_value = current_values[property.name]
         if property.should && !property.safe_insync?(current_value)


### PR DESCRIPTION
If transition were used with a resource with no `ensure` parameter (like
a notify) then it would stacktrace. This corrects that and adds an
example to validate that the type is working properly.