### PR TITLE
(SUP-2799) Update to Supportable OS and Puppet Versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,11 @@ fixtures:
   forge_modules:
 #     stdlib: "puppetlabs/stdlib"
   repositories:
-    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'https://github.com/puppetlabs/provision.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
+    provision: 'https://github.com/puppetlabs/provision'
+    bootstrap: 'https://github.com/puppetlabs/puppetlabs-bootstrap'
+    puppet_conf: 'https://github.com/puppetlabs/puppetlabs-puppet_conf'
+    ruby_task_helper: 'https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'

--- a/metadata.json
+++ b/metadata.json
@@ -10,36 +10,96 @@
   "dependencies": [
 
   ],
-  "operatingsystem_support": [
+    "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat"
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
     },
     {
-      "operatingsystem": "Windows"
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7"
+      ]
     },
     {
-      "operatingsystem": "Debian"
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7"
+      ]
     },
     {
-      "operatingsystem": "Ubuntu"
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "7"
+      ]
     },
     {
-      "operatingsystem": "OS X"
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12",
+        "15"
+      ]
     },
     {
-      "operatingsystem": "Solaris"
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
     },
     {
-      "operatingsystem": "SLES"
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "18.04",
+        "20.04"
+      ]
     },
     {
-      "operatingsystem": "AIX"
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "2012",
+        "2012 R2",
+        "2016",
+        "2019",
+        "7",
+        "8.1",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "7.1",
+        "7.2"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Prior to this commit, 
This Module Stated Support For Version 3 of Puppet and Higher, this has been changed to Version 6 and Higher to Ensure supportability and proper test coverage

IN addition, fixtures to allow the proper running of the CI were put in place